### PR TITLE
Refactoring: deprecate Feeder API from v0.13.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 INDEXER_BRIDGED_TOKENS_FILE=mainnet.json   # full list of files you can find in repo ./build/bridged_tokens/
 INDEXER_CLASS_INTERFACES_DIR=./interfaces/ # REQUIRED
-INDEXER_DATASOURCE=sequencer               # REQUIRED: one of 'node' or 'sequencer'
+INDEXER_DATASOURCE=node               # REQUIRED: 'node' is only one supported value
 HASURA_HOST=hasura
 HASURA_POSTGRES_HOST=db
 LOG_LEVEL=info
@@ -9,6 +9,5 @@ POSTGRES_HOST=db
 POSTGRES_DB=starknet
 POSTGRES_PASSWORD=<TYPE_SOMETHING_STRONG>     # REQUIRED
 STARKNET_NODE_URL=<URL_HERE>                  # REQUIRED if INDEXER_DATASOURCE=node
-STARKNET_SEQUENCER_FEEDER_GATEWAY=<URL_HERE>  # REQUIRED if INDEXER_DATASOURCE=sequencer
 NODE_APIKEY=<API_KEY_FROM_NODE_PROVIDER>      # REQUIRED if your node provider has api key. It's api key.
 NODE_HEADER_APIKEY=<HEADER_NAME>              # REQUIRED if your node provider has api key. It's header name.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Starknet indexer
-This is an indexing layer for Starknet written in Golang that operates on top of the (Feeder) Gateway API and stores data in a Postgres database.  
+This is an indexing layer for Starknet written in Golang that operates on top of the Node API and stores data in a Postgres database.  
 
 It can be used in multiple ways and for various purposes:
 - As a base component for the [DipDup Vertical](https://dipdup.io) — GraphQL federation providing a wide range of APIs for accessing both on-chain and off-chain data/metadata

--- a/build/dipdup.yml
+++ b/build/dipdup.yml
@@ -19,9 +19,6 @@ datasources:
   node:
     url: ${STARKNET_NODE_URL}
     rps: ${STARKNET_NODE_RPS:-5}
-  sequencer:
-    url: ${STARKNET_SEQUENCER_FEEDER_GATEWAY:-https://alpha-mainnet.starknet.io/feeder_gateway}
-    rps: ${STARKNET_SEQUENCER_RPS:-3}
 
 database:
   kind: postgres

--- a/pkg/indexer/receiver/api.go
+++ b/pkg/indexer/receiver/api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/dipdup-io/starknet-go-api/pkg/data"
 	starknetData "github.com/dipdup-io/starknet-go-api/pkg/data"
 	starknet "github.com/dipdup-io/starknet-go-api/pkg/sequencer"
 	"github.com/dipdup-io/starknet-indexer/internal/storage"
@@ -36,9 +35,9 @@ type Block struct {
 
 type Transaction struct {
 	Type      string
-	Version   data.Felt
-	Hash      data.Felt
-	ActualFee data.Felt
+	Version   starknetData.Felt
+	Hash      starknetData.Felt
+	ActualFee starknetData.Felt
 
 	Body any
 }

--- a/pkg/indexer/receiver/feeder.go
+++ b/pkg/indexer/receiver/feeder.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/dipdup-io/starknet-go-api/pkg/data"
 	starknetData "github.com/dipdup-io/starknet-go-api/pkg/data"
 	"github.com/dipdup-io/starknet-go-api/pkg/encoding"
 	starknet "github.com/dipdup-io/starknet-go-api/pkg/sequencer"
@@ -36,8 +35,8 @@ func (f *Feeder) GetBlock(ctx context.Context, blockId starknetData.BlockID) (bl
 
 	block.Height = response.BlockNumber
 	block.Time = time.Unix(response.Timestamp, 0).UTC()
-	block.Hash = data.Felt(response.BlockHash).Bytes()
-	block.ParentHash = data.Felt(response.ParentHash).Bytes()
+	block.Hash = starknetData.Felt(response.BlockHash).Bytes()
+	block.ParentHash = starknetData.Felt(response.ParentHash).Bytes()
 	block.NewRoot = encoding.MustDecodeHex(response.NewRoot)
 	block.SequencerAddress = encoding.MustDecodeHex(response.SequencerAddress)
 	block.Version = response.StarknetVersion

--- a/pkg/indexer/receiver/node.go
+++ b/pkg/indexer/receiver/node.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/dipdup-io/starknet-go-api/pkg/data"
 	starknetData "github.com/dipdup-io/starknet-go-api/pkg/data"
 	"github.com/dipdup-io/starknet-go-api/pkg/encoding"
 	starknet "github.com/dipdup-io/starknet-go-api/pkg/rpc"
@@ -39,8 +38,8 @@ func (n *Node) GetBlock(ctx context.Context, blockId starknetData.BlockID) (bloc
 
 	block.Height = response.Result.BlockNumber
 	block.Time = time.Unix(response.Result.Timestamp, 0).UTC()
-	block.Hash = data.Felt(response.Result.BlockHash).Bytes()
-	block.ParentHash = data.Felt(response.Result.ParentHash).Bytes()
+	block.Hash = starknetData.Felt(response.Result.BlockHash).Bytes()
+	block.ParentHash = starknetData.Felt(response.Result.ParentHash).Bytes()
 	block.NewRoot = encoding.MustDecodeHex(response.Result.NewRoot)
 	block.SequencerAddress = encoding.MustDecodeHex(response.Result.SequencerAddress)
 	block.Version = response.Result.Version

--- a/pkg/indexer/receiver/receiver.go
+++ b/pkg/indexer/receiver/receiver.go
@@ -46,6 +46,8 @@ func NewReceiver(cfg config.Config, ds map[string]ddConfig.DataSource) (*Receive
 	switch cfg.Datasource {
 	case "node":
 		api = NewNode(dsCfg)
+	default:
+		return nil, errors.Errorf("usupported datasource type: %s", cfg.Datasource)
 	}
 
 	receiver := &Receiver{

--- a/pkg/indexer/receiver/receiver.go
+++ b/pkg/indexer/receiver/receiver.go
@@ -46,8 +46,6 @@ func NewReceiver(cfg config.Config, ds map[string]ddConfig.DataSource) (*Receive
 	switch cfg.Datasource {
 	case "node":
 		api = NewNode(dsCfg)
-	case "sequencer":
-		api = NewFeeder(dsCfg)
 	}
 
 	receiver := &Receiver{


### PR DESCRIPTION
[Release Notes of starknet version 0.13.2](https://docs.starknet.io/starknet-versions/version-notes/#feeder_gateway)