### PR TITLE
fix typo block.go

### DIFF
--- a/internal/storage/block.go
+++ b/internal/storage/block.go
@@ -27,7 +27,7 @@ type Block struct {
 	Version *string   `comment:"The version of the Starknet protocol used when creating this block"`
 
 	TxCount            int `comment:"Transactions count in block"`
-	InvokeCount        int `comment:"Ivokes count in block"`
+	InvokeCount        int `comment:"Invokes count in block"`
 	DeclareCount       int `comment:"Declares count in block"`
 	DeployCount        int `comment:"Deploys count in block"`
 	DeployAccountCount int `comment:"Deploy accounts count in block"`


### PR DESCRIPTION
# **Fix Typo in `block.go`**

## **Description**
This pull request fixes a typo in the `block.go` file. The word **"Ivokes"** has been corrected to **"Invokes"** for consistency and accuracy in the code comments.

## **Changes**
- Corrected the typo in the comment:
  - **Before:** `InvokeCount        int \`comment:"Ivokes count in block"\``
  - **After:** `InvokeCount        int \`comment:"Invokes count in block"\``

## **Impact**
- This change only impacts the comment and does not affect functionality. It helps to improve the clarity of the code.

## **Testing**
- No testing needed as this is a simple typo fix.
