### PR TITLE
Fix typo receiver.go

### DIFF
--- a/pkg/indexer/receiver/receiver.go
+++ b/pkg/indexer/receiver/receiver.go
@@ -80,7 +80,7 @@ func NewReceiver(cfg config.Config, ds map[string]ddConfig.DataSource) (*Receive
 	case "node":
 		api = NewNode(dsCfg)
 	default:
-		return nil, errors.Errorf("usupported datasource type: %s", cfg.Datasource)
+		return nil, errors.Errorf("unsupported datasource type: %s", cfg.Datasource)
 	}
 
 	receiver := &Receiver{


### PR DESCRIPTION
Title:
Fix typo in receiver.go (usupported → unsupported)

Description:
This pull request corrects a typo in the receiver.go file, changing "usupported" to "unsupported." This minor update improves code clarity and ensures proper terminology.